### PR TITLE
Fix for $this->settings not existing

### DIFF
--- a/includes/curl.inc
+++ b/includes/curl.inc
@@ -14,6 +14,11 @@ class GatherContentCurl extends GatherContentFunctions {
   private $defaultFilter = '';
   private $idsUsed = array();
   private $hasTitles = array();
+  private $settings = array();
+
+  public function __construct() {
+    $this->settings['project_id'] = variable_get('gathercontent_project_id');
+  }
 
   /**
    * Return parent id associated with a specific page.


### PR DESCRIPTION
GatherContentCurl::getParentPageID() has references to GatherContentCurl::$settings['project_id'], but that settings property doesn't exist. 

I'm not sure of the best way to fix getParentPageID(), so instead I simply had the class make that variable with the one property that's needed.