### PR TITLE
Support metatags as field when importing nodes

### DIFF
--- a/includes/curl.inc
+++ b/includes/curl.inc
@@ -431,6 +431,15 @@ class GatherContentCurl extends GatherContentFunctions {
       </li>';
     foreach ($this->post_types as $name => $title) {
       $instances = field_info_instances('node', $name);
+
+      if (module_exists('metatag') && function_exists('metatag_entity_supports_metatags')) {
+        if (metatag_entity_supports_metatags('node', $name)) {
+          $instances['metatags'] = array(
+            'label' => t('Metatags'),
+          );
+        }
+      }
+
       if (isset($instances['body'])) {
         unset($instances['body']);
         $html .= '

--- a/includes/pages_import.inc
+++ b/includes/pages_import.inc
@@ -288,7 +288,7 @@ function gathercontent_import_page() {
 
           $save_settings['fields'][$tab . '_' . $field_name] = $map_to;
 
-          if ($map_to != 'title') {
+          if ($map_to != 'title' && $map_to != 'metatags') {
             $cur_field = $entity->{$map_to}->info();
             if ($field['type'] == 'files') {
               if (is_array($field['value']) && count($field['value']) > 0) {
@@ -329,7 +329,13 @@ function gathercontent_import_page() {
             }
           }
 
-          if ($map_to == 'title') {
+          if ($map_to === 'metatags') {
+            $raw_entity = $entity->value();
+            $raw_entity->metatags = array(LANGUAGE_NONE => array(
+              'title' => $field,
+            ));
+          }
+          else if ($map_to == 'title') {
             $entity->title->set(strip_tags($field['value']));
           }
           elseif (!empty($field['value'])) {


### PR DESCRIPTION
Added the ability to map certain fields in Gathercontent to metatag title field (with the Drupal metatag module).