### PR TITLE
Added redirect as mapping field when applicable

### DIFF
--- a/includes/curl.inc
+++ b/includes/curl.inc
@@ -440,6 +440,12 @@ class GatherContentCurl extends GatherContentFunctions {
         }
       }
 
+      if (module_exists('redirect')) {
+        $instances['redirect'] = array(
+          'label' => t('Redirect'),
+        );
+      }
+
       if (isset($instances['body'])) {
         unset($instances['body']);
         $html .= '

--- a/includes/pages_import.inc
+++ b/includes/pages_import.inc
@@ -264,6 +264,7 @@ function gathercontent_import_page() {
       }
 
       $field_values = array();
+      $redirects = array();
 
       if (isset($gc['fields'])) {
         foreach ($gc['fields'] as $info) {
@@ -288,7 +289,7 @@ function gathercontent_import_page() {
 
           $save_settings['fields'][$tab . '_' . $field_name] = $map_to;
 
-          if ($map_to != 'title' && $map_to != 'metatags') {
+          if ($map_to != 'title' && $map_to != 'metatags' && $map_to != 'redirect') {
             $cur_field = $entity->{$map_to}->info();
             if ($field['type'] == 'files') {
               if (is_array($field['value']) && count($field['value']) > 0) {
@@ -329,7 +330,22 @@ function gathercontent_import_page() {
             }
           }
 
-          if ($map_to === 'metatags') {
+          if ($map_to === 'redirect') {
+            foreach(array_map('trim', explode(',', strip_tags($field['value']))) as $redirect) {
+              if (url_is_external($redirect)) {
+                $redirect = parse_url($redirect, PHP_URL_PATH);
+              }
+
+              $uri = ltrim($redirect, '/');
+
+              if (!valid_url($uri)) {
+                continue;
+              }
+
+              $redirects[] = $uri;
+            }
+          }
+          else if ($map_to === 'metatags') {
             $raw_entity = $entity->value();
             $raw_entity->metatags = array(LANGUAGE_NONE => array(
               'title' => $field,
@@ -482,6 +498,23 @@ function gathercontent_import_page() {
       $save_settings['overwrite'] = $entity->getIdentifier();
 
       $entity_uri = entity_uri($entity->type(), $entity->value());
+
+      if (module_exists('redirect')) {
+        foreach ($redirects as $uri) {
+          $redirect = new stdClass();
+          redirect_object_prepare($redirect);
+          $redirect->source = $uri;
+          $redirect->redirect = $entity_uri['path'];
+          $redirect->language = LANGUAGE_NONE;
+          // Check if the redirect exists before saving.
+          $hash = redirect_hash($redirect);
+
+          if (!redirect_load_by_hash($hash)) {
+            redirect_save($redirect);
+          }
+        }
+      }
+
       $mlid = gathercontent_create_menu_item($entity->title->value(), $save_settings['parent_id'], $entity_uri['path']);
 
       $media = variable_get('gathercontent_media_files');


### PR DESCRIPTION
When the redirect module is enabled, I've added a possibility to map a certain Gathercontent field to a redirect.
So if you're writing content in GatherContent, you can now enter the old URL's (seperated by comma's) in a field and map them to the redirect field.