### PR TITLE
Feature/summary

### DIFF
--- a/includes/curl.inc
+++ b/includes/curl.inc
@@ -446,6 +446,11 @@ class GatherContentCurl extends GatherContentFunctions {
       <li data-post-type="' . $name . '" data-search="body">
         <a href="#" data-value="body">' . t('Body') . '</a>
       </li>';
+
+        $html .= '
+      <li data-post-type="' . $name . '" data-search="summary">
+        <a href="#" data-value="body[summary]">' . t('Summary') . '</a>
+      </li>';
       }
 
       if (isset($this->hasTitles[$name])) {

--- a/includes/pages_import.inc
+++ b/includes/pages_import.inc
@@ -288,6 +288,13 @@ function gathercontent_import_page() {
 
           $save_settings['fields'][$tab . '_' . $field_name] = $map_to;
 
+          $sub_field = 'value';
+          $regex = '/\[(.+)\]$/';
+          if (preg_match($regex, $map_to, $matches)) {
+            $sub_field = $matches[1];
+            $map_to = preg_replace($regex, '', $map_to);
+          }
+
           if ($map_to != 'title' && $map_to != 'metatags') {
             $cur_field = $entity->{$map_to}->info();
             if ($field['type'] == 'files') {
@@ -455,17 +462,17 @@ function gathercontent_import_page() {
               }
               if (!isset($field_values[$map_to])) {
                 $field_values[$map_to] = array(
-                  'value' => '',
+                  $sub_field => '',
                   'format' => $save_settings['filter'],
                 );
               }
 
-              $val = $field_values[$map_to]['value'];
+              $val = $field_values[$map_to][$sub_field];
               if (!empty($val)) {
                 $val .= "\n";
               }
               $val .= $field['value'];
-              $field_values[$map_to]['value'] = $val;
+              $field_values[$map_to][$sub_field] = $val;
             }
             else {
               $field['value'] = strip_tags($field['value']);


### PR DESCRIPTION
I've added the possibility of importing a field to the summary (instead of body field).
So now you can have two separate fields in GatherContent and import one to the summary and the other to the full body.

Note that with this fix I've added the possibility of more fine grained importing options.
Before, a node was always imported inside the 'value' property. For example: $node->field_myfield = array('value' => $content);

With this change, it's possible to import it as:
$node->field_myfield = array('myotherfield' => $content);
when you do: data-value="field_myfield[myotherfield]".

